### PR TITLE
Update Index to match "Project History" heading

### DIFF
--- a/docs/source/_templates/index.html
+++ b/docs/source/_templates/index.html
@@ -10,7 +10,7 @@
     <td width="50%" valign="top">
       <p class="biglink"><div class="section-title">{%trans%}The project{%endtrans%}</div>
          - <a class="linkdescr" href="{{ pathto("the-project/what-is-freedomotic") }}">{%trans%}What is Freedomotic?{%endtrans%}</a><br/>
-         - <a class="linkdescr" href="{{ pathto("the-project/project-history") }}">{%trans%}The project history{%endtrans%}</a><br/>
+         - <a class="linkdescr" href="{{ pathto("the-project/project-history") }}">{%trans%}Project History{%endtrans%}</a><br/>
          - <a class="linkdescr" href="{{ pathto("the-project/team") }}">{%trans%}Team{%endtrans%}</a><br/>
          - <a class="linkdescr" href="{{ pathto("the-project/features") }}">{%trans%}Features{%endtrans%}</a><br/>
          - <a class="linkdescr" href="{{ pathto("the-project/press") }}">{%trans%}Press & Presentations{%endtrans%}</a><br/>


### PR DESCRIPTION
I noticed that after https://github.com/freedomotic/fd-user-manual/pull/4 was integrated that the side menu entry at http://freedomotic-user-manual.readthedocs.io/en/latest/the-project/project-history.html no longer matched the pages heading of **"Project History"** _(used to be "The project history")_.

This change makes the inex file match the same heading of **Project History**.

This goes along with the fixes requested here: https://github.com/freedomotic/fd-user-manual/issues/3

Happy Hacktoberfest!